### PR TITLE
fix the http issue

### DIFF
--- a/src/js/coder.js
+++ b/src/js/coder.js
@@ -106,7 +106,7 @@ let coder = new Vue({
     },
     filters: {
         fixURL: value => {
-            if (!value.startsWith('http://') || !value.startsWith('https://')) {
+            if (!value.startsWith('http://') && !value.startsWith('https://')) {
                 value = `https://${value}`;
             }
             return value;


### PR DESCRIPTION
We want to add 'https' in the case that the link does not have 'http' ot 'https' already. i.e if( ! (value.startsWith('http://') || (value.startsWith('https://') )
which on simplification with De Morgans's laws wpuld lead to :  if (!value.startsWith('http://') && !value.startsWith('https://'))